### PR TITLE
Refactor Ads to be able to retrieve the newest ads

### DIFF
--- a/src/main/migrations.sql
+++ b/src/main/migrations.sql
@@ -1,0 +1,23 @@
+USE jtt_adlister_db;
+
+DROP TABLE IF EXISTS ads;
+DROP TABLE IF EXISTS users;
+
+CREATE TABLE users (
+  id       BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT,
+  username VARCHAR(50) UNIQUE  NOT NULL,
+  email    VARCHAR(255) UNIQUE NOT NULL,
+  password VARCHAR(100)        NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE ads (
+  id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  user_id     BIGINT UNSIGNED NOT NULL,
+  title       VARCHAR(255)    NOT NULL,
+  description TEXT            NOT NULL,
+  created_at  DATETIME        NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY (user_id) REFERENCES users (id)
+    ON DELETE CASCADE
+);


### PR DESCRIPTION
- [x] Update Ads table to have a `created_at` column
- [x] Update Ad model to store the `timeCreated` timestamp
- [x] Update the Ads interface include a method to retrieve the newest `limit` ads
- [x] Update the MySQLAdsDao to implement the above-mentioned method
- [x] Create a Site Index Controller named `SiteIndexServlet.java`
- [x] Retrieve the 3 newest Ads from the MySQLAdsDao and store them in the Site Index Controller  
- [ ] Create a TimestampSpan utility class to calculate differences between Timestamps 
- [ ] Update the site index.jsp file to display the newest 3 Ads